### PR TITLE
feat: add confetti burst on mobilab logo tap

### DIFF
--- a/ios/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,14 @@
+{
+  "pins" : [
+    {
+      "identity" : "appauth-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/openid/AppAuth-iOS",
+      "state" : {
+        "revision" : "145104f5ea9d58ae21b60add007c33c1cc0c948e",
+        "version" : "2.0.0"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/ios/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,14 @@
+{
+  "pins" : [
+    {
+      "identity" : "appauth-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/openid/AppAuth-iOS",
+      "state" : {
+        "revision" : "145104f5ea9d58ae21b60add007c33c1cc0c948e",
+        "version" : "2.0.0"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/lib/core/constants/app_colors.dart
+++ b/lib/core/constants/app_colors.dart
@@ -46,4 +46,14 @@ class AppColors {
   static final orange9 = const Color(0xFFE67E22).withValues(alpha: 0.094);
   static final red9 = const Color(0xFFE74C3C).withValues(alpha: 0.094);
   static final pink9 = const Color(0xFFE84393).withValues(alpha: 0.094);
+
+  // For mobilab icon button confetti colors
+  static const List<Color> confetti = [
+    coral,
+    darkOrange,
+    green,
+    secondaryBlue,
+    purple,
+    orange,
+  ];
 }

--- a/lib/core/constants/app_sizes.dart
+++ b/lib/core/constants/app_sizes.dart
@@ -3,6 +3,10 @@ class AppSizes {
   static const icon = 26.0;
   static const iconLarge = 40.0;
 
+  /// Shell app bar logos (see [ShellPage]).
+  static const double shellLeadingLogo = 36.0;
+  static const double shellTitleLogo = 44.0;
+
   static const double smallSpace = 4.0;
   static const double midSpace = 8.0;
   static const double bigSpace = 12.0;

--- a/lib/core/shell_page.dart
+++ b/lib/core/shell_page.dart
@@ -1,15 +1,38 @@
+import 'package:confetti/confetti.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:go_router/go_router.dart';
 import 'package:sky_app/core/constants/app_assets.dart';
 import 'package:sky_app/core/constants/app_colors.dart';
 import 'package:sky_app/core/constants/app_radiuses.dart';
+import 'package:sky_app/core/constants/app_sizes.dart';
 import 'package:sky_app/core/widgets/nav_item.dart';
 
-class ShellPage extends StatelessWidget {
+class ShellPage extends StatefulWidget {
   const ShellPage({super.key, required this.child});
 
   final Widget child;
+
+  @override
+  State<ShellPage> createState() => _ShellPageState();
+}
+
+class _ShellPageState extends State<ShellPage> {
+  late final ConfettiController _confettiController;
+
+  @override
+  void initState() {
+    super.initState();
+    _confettiController = ConfettiController(
+      duration: const Duration(milliseconds: 800),
+    );
+  }
+
+  @override
+  void dispose() {
+    _confettiController.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -20,7 +43,7 @@ class ShellPage extends StatelessWidget {
       appBar: appBar(context),
       body: Stack(
         children: [
-          child,
+          widget.child,
           Positioned(
             left: 0,
             right: 0,
@@ -42,6 +65,11 @@ class ShellPage extends StatelessWidget {
               ),
             ),
           ),
+          Positioned(
+            top: -10,
+            left: 40,
+            child: CustomConfetti(confettiController: _confettiController),
+          ),
         ],
       ),
       bottomNavigationBar: navBar(currentLocation, context),
@@ -52,7 +80,7 @@ class ShellPage extends StatelessWidget {
     return Padding(
       padding: const EdgeInsets.only(left: 16, right: 16, bottom: 30, top: 10),
       child: Container(
-        padding: EdgeInsets.all(8),
+        padding: const EdgeInsets.all(AppSizes.midSpace),
         decoration: BoxDecoration(
           color: AppColors.tileBackgroundColor.withValues(alpha: 0.95),
           borderRadius: BorderRadius.circular(AppRadiuses.navbar),
@@ -129,22 +157,12 @@ class ShellPage extends StatelessWidget {
       centerTitle: true,
       title: SvgPicture.asset(
         AppAssets.skylab,
-        width: 44,
-        height: 44,
+        width: AppSizes.shellTitleLogo,
+        height: AppSizes.shellTitleLogo,
         fit: BoxFit.contain,
       ),
       leadingWidth: 60,
-      leading: Padding(
-        padding: const EdgeInsets.all(8),
-        child: Center(
-          child: SvgPicture.asset(
-            AppAssets.mobilab,
-            width: 36,
-            height: 36,
-            fit: BoxFit.contain,
-          ),
-        ),
-      ),
+      leading: MobilabIconButton(confettiController: _confettiController),
       // actions: [
       //   Padding(
       //     padding: const EdgeInsets.only(right: 5),
@@ -165,6 +183,55 @@ class ShellPage extends StatelessWidget {
       //     ),
       //   ),
       // ],
+    );
+  }
+}
+
+class MobilabIconButton extends StatelessWidget {
+  const MobilabIconButton({super.key, required this._confettiController});
+
+  final ConfettiController _confettiController;
+
+  @override
+  Widget build(BuildContext context) {
+    return IconButton(
+      onPressed: () {
+        _confettiController.stop();
+        _confettiController.play();
+      },
+      padding: EdgeInsets.zero,
+      highlightColor: Colors.transparent,
+      splashColor: Colors.transparent,
+      hoverColor: Colors.transparent,
+      icon: SvgPicture.asset(
+        AppAssets.mobilab,
+        width: AppSizes.shellLeadingLogo,
+        height: AppSizes.shellLeadingLogo,
+        fit: BoxFit.contain,
+      ),
+    );
+  }
+}
+
+class CustomConfetti extends StatelessWidget {
+  const CustomConfetti({super.key, required this._confettiController});
+
+  final ConfettiController _confettiController;
+
+  @override
+  Widget build(BuildContext context) {
+    return ConfettiWidget(
+      confettiController: _confettiController,
+      blastDirectionality: BlastDirectionality.directional,
+      blastDirection: 0.5, // ~30 degrees, toward bottom-right
+      shouldLoop: false,
+      numberOfParticles: 50,
+      maxBlastForce: 30,
+      minBlastForce: 15,
+      gravity: 0.25,
+      emissionFrequency: 0.05,
+      particleDrag: 0.05,
+      colors: AppColors.confetti,
     );
   }
 }

--- a/lib/core/shell_page.dart
+++ b/lib/core/shell_page.dart
@@ -68,7 +68,7 @@ class _ShellPageState extends State<ShellPage> {
           Positioned(
             top: -10,
             left: 40,
-            child: CustomConfetti(confettiController: _confettiController),
+            child: _customConfetti(),
           ),
         ],
       ),
@@ -162,7 +162,7 @@ class _ShellPageState extends State<ShellPage> {
         fit: BoxFit.contain,
       ),
       leadingWidth: 60,
-      leading: MobilabIconButton(confettiController: _confettiController),
+      leading: _mobilabIconButton(),
       // actions: [
       //   Padding(
       //     padding: const EdgeInsets.only(right: 5),
@@ -185,15 +185,8 @@ class _ShellPageState extends State<ShellPage> {
       // ],
     );
   }
-}
 
-class MobilabIconButton extends StatelessWidget {
-  const MobilabIconButton({super.key, required this._confettiController});
-
-  final ConfettiController _confettiController;
-
-  @override
-  Widget build(BuildContext context) {
+  Widget _mobilabIconButton() {
     return IconButton(
       onPressed: () {
         _confettiController.stop();
@@ -211,15 +204,8 @@ class MobilabIconButton extends StatelessWidget {
       ),
     );
   }
-}
 
-class CustomConfetti extends StatelessWidget {
-  const CustomConfetti({super.key, required this._confettiController});
-
-  final ConfettiController _confettiController;
-
-  @override
-  Widget build(BuildContext context) {
+  Widget _customConfetti() {
     return ConfettiWidget(
       confettiController: _confettiController,
       blastDirectionality: BlastDirectionality.directional,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -89,6 +89,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.19.1"
+  confetti:
+    dependency: "direct main"
+    description:
+      name: confetti
+      sha256: "979aafde2428c53947892c95eb244466c109c129b7eee9011f0a66caaca52267"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.0"
   crypto:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -27,6 +27,7 @@ dependencies:
   flutter_svg: 2.3.0
   carousel_slider: 5.1.2
   timeago: 3.7.1
+  confetti: 0.7.0
 
   #Web & External Links
   dio: 5.9.2
@@ -42,6 +43,7 @@ dependencies:
   #Auth
   flutter_appauth: 12.0.1
   crypto: 3.0.7
+  
 
 
 dev_dependencies:


### PR DESCRIPTION
## What
Tapping the Mobilab logo in the AppBar now triggers a directional confetti burst from the top-left corner.

## Changes
- Converted `ShellPage` to `StatefulWidget` to manage `ConfettiController` lifecycle
- Extracted `MobilabIconButton` and `CustomConfetti` as reusable widgets
- Added `confetti: 0.7.0` dependency
- Added confetti color palette to `AppColors`
- Added new sizing constants to `AppSizes`

## Testing
- Tested locally on Chrome (debug build)
- `flutter analyze`: no issues
- No router/auth/business logic changes